### PR TITLE
Add html-proofer to travis CI

### DIFF
--- a/tests/cibuild.sh
+++ b/tests/cibuild.sh
@@ -6,4 +6,4 @@ bundle exec jekyll build
 
 #These tests check if your image references,
 #alt tags, internal links...
-#bundle exec htmlproof ./_site --only-4xx  --check-html --href-ignore "#"
+bundle exec htmlproof ./_site --only-4xx  --check-html --href-ignore "#"


### PR DESCRIPTION
Currently Fails to validate (find) internal link, even when they are indeed present:

``` sh
- ./_site/about/index.html
  *  internal script /web/assets/bootstrap/3.3.4/js/bootstrap.min.js does not exist (line 131)
  *  internal script /web/assets/chartjs/1.0.2/chart.min.js does not exist (line 128)
  *  internal script /web/assets/d3/d3.v3.min.js does not exist (line 127)
```

but it's there, and browser finds it:
<img width="689" alt="screen shot 2015-07-24 at 4 06 39 pm" src="https://cloud.githubusercontent.com/assets/434029/8883613/22af05ce-321e-11e5-994f-102d7784e436.png">

....
