### PR TITLE
Load function from URL

### DIFF
--- a/assets/list.js
+++ b/assets/list.js
@@ -29,12 +29,14 @@ $( document ).ready(load_data());
 
 function load_data_state(){
   var data_state= getURLParameter('data');
-  switch(data_state) {
-    case "full_list":
-        full_list();
-        break;
-    default:
-        vizs();
+  var defined_functions = Object.keys(window).filter(function(x)
+  {
+    if (!(window[x] instanceof Function)) return false;
+    return !/\[native code\]/.test(window[x].toString()) ? true : false;
+  });
+
+  if ( defined_functions.indexOf(data_state) > -1 ){
+    window[data_state]();
   }
 }
 


### PR DESCRIPTION
Run a function specified on the url like `http://localhost:4000/web/list/?data=list_indicators` but only if the function is page defined.

Avoids using `eval` which is a security risk, but allows to specify a data state in the URL
